### PR TITLE
doc: update usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ npm install -g tsuml2
 ## Usage
 
 ```
-tsuml2 --glob ./src/**/*.ts 
+tsuml2 --glob "./src/**/*.ts" 
 ```
 To avoid getting unwanted interfaces / classes you might want to exclude d.ts and spec.ts files:
 ```
-tsuml2 --glob ./src/**/!(*.d|*.spec).ts
+tsuml2 --glob "./src/**/!(*.d|*.spec).ts"
 ```
 
 ### Options


### PR DESCRIPTION
Glob patterns are likely to be expanded by shell and better be escaped. For example, `-g ./src/demo/*.ts` will only match the first file. See https://github.com/yargs/yargs/issues/50#issuecomment-54087619