### PR TITLE
bugfix: override default settings with user settings

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -84,10 +84,10 @@ export function createNomnomlSVG(settings: TsUML2Settings) {
   // emit
   console.log(chalk.yellow("\nemitting declarations:"));
   const dsl = emit(declarations);
-
-  if(SETTINGS.outDsl !== "") {
+  const outDSL = settings.outDsl || SETTINGS.outDsl;
+  if(outDSL !== "") {
     console.log(chalk.green("\nwriting DSL"));
-    fs.writeFile(SETTINGS.outDsl,dsl,(err) => {
+    fs.writeFile(outDSL,dsl,(err) => {
       if(err) {
           console.log(chalk.redBright("Error writing DSL file: " + err));
       }
@@ -95,15 +95,16 @@ export function createNomnomlSVG(settings: TsUML2Settings) {
   }
 
   //render
+  const outFile = settings.outFile || SETTINGS.outFile
   console.log(chalk.yellow("\nrender to svg"));
   let svg = renderNomnomlSVG(dsl);
   if(settings.typeLinks) {
     console.log(chalk.yellow("\nadding type links to svg"));
-    svg = postProcessSvg(svg,settings.outFile, declarations);
+    svg = postProcessSvg(svg,outFile, declarations);
   }
 
   console.log(chalk.green("\nwriting SVG"));
-  fs.writeFile(SETTINGS.outFile,svg,(err) => {
+  fs.writeFile(outFile,svg,(err) => {
     if(err) {
         console.log(chalk.redBright("Error writing file: " + err));
     }


### PR DESCRIPTION
Currently `outFile` path is being used from `SETTINGS` variable https://github.com/demike/TsUML2/blob/18f381c0682075d7e6b9a1f5797d1d7f7c70d3f2/src/core/index.ts#L106 
Due to which output file is not getting saved on user specified location. Similarly there are few more properties which should be override if user settings is passed.

In below example output file should be saved on specified path

```
const t = require('tsuml2')


t.createNomnomlSVG({glob: `D:/apps/src/app/**/!(*.d|*.spec).ts`,outFile: 'D:/apps/src/demo.svg'});
```