### PR TITLE
added line separator between dsl headers and dsl body

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -126,7 +126,7 @@ async function createMermaidDSL(declarations: FileDeclaration[], settings: TsUML
  */
 export function getNomnomlDSL(declarations: FileDeclaration[], settings: TsUML2Settings) {
   console.log(chalk.yellow("\nemitting nomnoml declarations:"));
-  return getNomnomlDSLHeader(settings) + emit(declarations, new Emitter(new NomnomlTemplate(settings)));
+  return getNomnomlDSLHeader(settings) + "\n" + emit(declarations, new Emitter(new NomnomlTemplate(settings)));
 }
 
 /**
@@ -137,7 +137,7 @@ export function getNomnomlDSL(declarations: FileDeclaration[], settings: TsUML2S
  */
 export function getMermaidDSL(declarations: FileDeclaration[], settings: TsUML2Settings) {
   console.log(chalk.yellow("\nemitting mermaid declarations:"));
-  return getMermaidDSLHeader(settings) + emit(declarations, new Emitter(new MermaidTemplate(settings)));
+  return getMermaidDSLHeader(settings) + "\n" + emit(declarations, new Emitter(new MermaidTemplate(settings)));
 }
 
 


### PR DESCRIPTION
Hello. My pull request fixes the nomnoml bug

**STR:**

1. download [repo](https://github.com/phpcoder2022/tsuml2-nomnoml-bug)
2. move to branch `bug-launcher`
3. `npm i`
4. `npm run build`
5. run `bash bug/run.sh`
6. see that diagram in bug/uml.svg is wrong

**How see action of my fix:**

Needly will do after all STR steps:

1. `git ch bug-fix src/core/index.ts`
2. `npm run build`
3. run `bash bug/run/sh`
4. see that diagram in bug/uml.svg is fine
