### PR TITLE
feat: add import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ tsuml2 --glob "./src/**/!(*.d|*.spec).ts"
                             strings, each representing a mermaid line), i.e.:
                             --mermaid "direction LR"                     [array]
       --outMermaidDsl       the path to the output mermaid DSL file     [string]
+  -i, --import              trace import files        [boolean] [default: false]
   -m, --memberAssociations  show associations between classes, interfaces, types
                             and their member types    [boolean] [default: false]
       --exportedTypesOnly   show only exported types, classes, interfaces, enums

--- a/src/core/parse-settings.ts
+++ b/src/core/parse-settings.ts
@@ -67,6 +67,12 @@ import * as fs  from "fs";
         }).option('config', {
             describe: "path to a json config file (command line options can be provided as keys in it)",
             string: true
+        }).option('import', {
+          describe: 'Automatically include import files',
+          alias: 'i',
+          boolean: true,
+          required: false,
+          default: settings.import,
         }).argv as Partial<TsUML2Settings & { config: string}>;
 
         if (argv.config) {
@@ -121,5 +127,9 @@ import * as fs  from "fs";
 
         if(argv.exportedTypesOnly != null && !(yargs.parsed as any).defaulted.exportedTypesOnly) {
             settings.exportedTypesOnly = argv.exportedTypesOnly;
+        }
+
+        if(argv.import != null && !(yargs.parsed as any).defaulted.import) {
+            settings.import = argv.import;
         }
     }

--- a/src/core/tsuml2-settings.ts
+++ b/src/core/tsuml2-settings.ts
@@ -61,6 +61,11 @@ export class TsUML2Settings {
      * show only exported types, classes, interfaces, enums
      */
     exportedTypesOnly = false;
+
+    /**
+     * automatically include import files
+     */
+    import = false;
 }
 
 /*


### PR DESCRIPTION
Hello,

While working with **orval** to generate type models, I wanted to visualize only the types connected to a specific root model using **Mermaid** diagrams.  
To support this, I added an `import` option and created a function called `getImportFiles`.

This function takes all files matched by the configured glob pattern, and recursively collects only the files that are imported from them.  
It skips anything inside `node_modules` and avoids duplicates.

When the import option is enabled, only the files that are directly or indirectly connected to the matched source files are included in the output:

```ts
const importFiles = settings?.import ? getImportFiles(ast) : [];
```

### Note

Since I am less familiar with the internal conventions of the parser module, I would appreciate any feedback or suggestions to ensure this approach aligns well with the existing structure.

Thank you for reviewing this contribution.
