### PR TITLE
fix: correct typo breaking --memberAssociations flag

### DIFF
--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -132,7 +132,7 @@ export class MemberAssociation {
         public readonly a: AssociationEnd, 
         public readonly b: AssociationEnd, 
         public readonly associationType: AssociationType = AssociationType.Association,
-        public inerhited = false) {}
+        public inherited = false) {}
 }
 
 export interface AssociationEnd {

--- a/src/core/parser/associations.ts
+++ b/src/core/parser/associations.ts
@@ -96,7 +96,7 @@ function checkInheritedAssociation(srcTypeId: string, associatedTypeId: string, 
         inherited = checkInheritedAssociation(base.id, associatedTypeId, associationMap, typeMap ) || inherited;
         if( inherited)
         {
-            associationMap.get(`${srcTypeId}_${associatedTypeId}`)!.inerhited = true;
+            associationMap.get(`${srcTypeId}_${associatedTypeId}`)!.inherited = true;
         }
 
     }
@@ -106,6 +106,6 @@ function checkInheritedAssociation(srcTypeId: string, associatedTypeId: string, 
 
 function deduplicateAssociations(declarations: FileDeclaration[]) {
     declarations.forEach(decl => {
-        decl.memberAssociations = decl.memberAssociations?.filter(ass => !ass.inerhited);
+        decl.memberAssociations = decl.memberAssociations?.filter(ass => !ass.inherited);
     }) 
 }


### PR DESCRIPTION
## Problem
Using `-m` or `--memberAssociations` causes the CLI to error out because the code uses the misspelled "inerhited" boolean instead of "inherited". This makes the feature unusable.

## Reproduction
`tsuml2 --glob "./src/**/*.ts"  -m` → error: `TypeError: Cannot set properties of undefined (setting 'inerhited')`

## Fix
Correct the typo in the code.

## Testing
Verified that `-m` now runs without error and produces the expected output.